### PR TITLE
chore: deprecate support 32 bit

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,7 +21,7 @@ builds:
     env:
       - CGO_ENABLED=0
     goos: [darwin, linux, windows]
-    goarch: [amd64, 386]
+    goarch: [amd64]
 
 archives:
   - name_template: >-


### PR DESCRIPTION
Lark sdk only supports 64bit because it is using `math.MaxInt64`

https://github.com/larksuite/oapi-sdk-go/issues/122